### PR TITLE
marked entities as Serializable (needed in several use-cases)

### DIFF
--- a/src/main/java/io/airlift/tpch/TpchEntity.java
+++ b/src/main/java/io/airlift/tpch/TpchEntity.java
@@ -13,7 +13,9 @@
  */
 package io.airlift.tpch;
 
-public interface TpchEntity
+import java.io.Serializable;
+
+public interface TpchEntity extends Serializable
 {
     long getRowNumber();
 


### PR DESCRIPTION
This has zero cost, and opens up the library for Java serialization scenarios