### PR TITLE
change lineitem.quantity from integer to double

### DIFF
--- a/src/main/java/io/airlift/tpch/LineItem.java
+++ b/src/main/java/io/airlift/tpch/LineItem.java
@@ -102,9 +102,14 @@ public class LineItem
         return lineNumber;
     }
 
-    public long getQuantity()
+    public double getQuantity()
     {
         return quantity;
+    }
+
+    public long getQuantityUnscaled()
+    {
+        return quantity * 100;
     }
 
     public double getExtendedPrice()

--- a/src/main/java/io/airlift/tpch/LineItemColumn.java
+++ b/src/main/java/io/airlift/tpch/LineItemColumn.java
@@ -58,11 +58,16 @@ public enum LineItemColumn
                 }
             },
 
-    QUANTITY("quantity", BIGINT)
+    QUANTITY("quantity", DOUBLE)
             {
-                public long getLong(LineItem lineItem)
+                public double getDouble(LineItem lineItem)
                 {
                     return lineItem.getQuantity();
+                }
+
+                public long getLong(LineItem lineItem)
+                {
+                    return lineItem.getQuantityUnscaled();
                 }
             },
 


### PR DESCRIPTION
This change is required to conform to the TPC-H spec. The 2.17.1 version
states that the lineitem.l_quantity field should be of decimal type (page
17), as opposed to the currently implemented integer.

I came across this when testing Presto with decimal on TPC-H queries and checking the results.

Not sure if I changed all the necessary bits.

cc @dain 