### PR TITLE
Change non-identifier columns to generate INTEGERs

### DIFF
--- a/src/main/java/io/airlift/tpch/CustomerColumn.java
+++ b/src/main/java/io/airlift/tpch/CustomerColumn.java
@@ -13,16 +13,16 @@
  */
 package io.airlift.tpch;
 
-import static io.airlift.tpch.TpchColumnType.BIGINT;
+import static io.airlift.tpch.TpchColumnType.IDENTIFIER;
 import static io.airlift.tpch.TpchColumnType.DOUBLE;
 import static io.airlift.tpch.TpchColumnType.VARCHAR;
 
 public enum CustomerColumn
         implements TpchColumn<Customer>
 {
-    CUSTOMER_KEY("custkey", BIGINT)
+    CUSTOMER_KEY("custkey", IDENTIFIER)
             {
-                public long getLong(Customer customer)
+                public long getIdentifier(Customer customer)
                 {
                     return customer.getCustomerKey();
                 }
@@ -44,9 +44,9 @@ public enum CustomerColumn
                 }
             },
 
-    NATION_KEY("nationkey", BIGINT)
+    NATION_KEY("nationkey", IDENTIFIER)
             {
-                public long getLong(Customer customer)
+                public long getIdentifier(Customer customer)
                 {
                     return customer.getNationKey();
                 }
@@ -67,7 +67,7 @@ public enum CustomerColumn
                     return customer.getAccountBalance();
                 }
 
-                public long getLong(Customer customer)
+                public long getIdentifier(Customer customer)
                 {
                     return customer.getAccountBalanceInCents();
                 }
@@ -117,7 +117,13 @@ public enum CustomerColumn
     }
 
     @Override
-    public long getLong(Customer customer)
+    public long getIdentifier(Customer customer)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getInteger(Customer customer)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/io/airlift/tpch/LineItem.java
+++ b/src/main/java/io/airlift/tpch/LineItem.java
@@ -25,7 +25,7 @@ public class LineItem
     private final long orderKey;
     private final long partKey;
     private final long supplierKey;
-    private final long lineNumber;
+    private final int lineNumber;
     private final long quantity;
     private final long extendedPrice;
     private final long discount;
@@ -43,7 +43,7 @@ public class LineItem
             long orderKey,
             long partKey,
             long supplierKey,
-            long lineNumber,
+            int lineNumber,
             long quantity,
             long extendedPrice,
             long discount,
@@ -97,12 +97,17 @@ public class LineItem
         return supplierKey;
     }
 
-    public long getLineNumber()
+    public int getLineNumber()
     {
         return lineNumber;
     }
 
-    public long getQuantity()
+    public double getQuantity()
+    {
+        return quantity / 100.0;
+    }
+
+    public long getQuantityInCents()
     {
         return quantity;
     }

--- a/src/main/java/io/airlift/tpch/LineItemColumn.java
+++ b/src/main/java/io/airlift/tpch/LineItemColumn.java
@@ -80,9 +80,9 @@ public enum LineItemColumn
                     return lineItem.getExtendedPrice();
                 }
 
-                public long getIdentifier(LineItem lingItem)
+                public long getIdentifier(LineItem lineItem)
                 {
-                    return lingItem.getExtendedPriceInCents();
+                    return lineItem.getExtendedPriceInCents();
                 }
             },
 

--- a/src/main/java/io/airlift/tpch/LineItemColumn.java
+++ b/src/main/java/io/airlift/tpch/LineItemColumn.java
@@ -14,55 +14,61 @@
 package io.airlift.tpch;
 
 import static io.airlift.tpch.GenerateUtils.formatDate;
-import static io.airlift.tpch.TpchColumnType.BIGINT;
+import static io.airlift.tpch.TpchColumnType.IDENTIFIER;
 import static io.airlift.tpch.TpchColumnType.DATE;
 import static io.airlift.tpch.TpchColumnType.DOUBLE;
+import static io.airlift.tpch.TpchColumnType.INTEGER;
 import static io.airlift.tpch.TpchColumnType.VARCHAR;
 
 public enum LineItemColumn
         implements TpchColumn<LineItem>
 {
     @SuppressWarnings("SpellCheckingInspection")
-    ORDER_KEY("orderkey", BIGINT)
+    ORDER_KEY("orderkey", IDENTIFIER)
             {
-                public long getLong(LineItem lineItem)
+                public long getIdentifier(LineItem lineItem)
                 {
                     return lineItem.getOrderKey();
                 }
             },
 
     @SuppressWarnings("SpellCheckingInspection")
-    PART_KEY("partkey", BIGINT)
+    PART_KEY("partkey", IDENTIFIER)
             {
-                public long getLong(LineItem lineItem)
+                public long getIdentifier(LineItem lineItem)
                 {
                     return lineItem.getPartKey();
                 }
             },
 
     @SuppressWarnings("SpellCheckingInspection")
-    SUPPLIER_KEY("suppkey", BIGINT)
+    SUPPLIER_KEY("suppkey", IDENTIFIER)
             {
-                public long getLong(LineItem lineItem)
+                public long getIdentifier(LineItem lineItem)
                 {
                     return lineItem.getSupplierKey();
                 }
             },
 
     @SuppressWarnings("SpellCheckingInspection")
-    LINE_NUMBER("linenumber", BIGINT)
+    LINE_NUMBER("linenumber", INTEGER)
             {
-                public long getLong(LineItem lineItem)
+                public int getInteger(LineItem lineItem)
                 {
                     return lineItem.getLineNumber();
                 }
             },
 
-    QUANTITY("quantity", BIGINT)
+    QUANTITY("quantity", DOUBLE)
             {
-                public long getLong(LineItem lineItem)
+                public double getDouble(LineItem lineItem)
                 {
                     return lineItem.getQuantity();
+                }
+
+                public long getIdentifier(LineItem lineItem)
+                {
+                    return lineItem.getQuantityInCents();
                 }
             },
 
@@ -74,7 +80,7 @@ public enum LineItemColumn
                     return lineItem.getExtendedPrice();
                 }
 
-                public long getLong(LineItem lingItem)
+                public long getIdentifier(LineItem lingItem)
                 {
                     return lingItem.getExtendedPriceInCents();
                 }
@@ -87,7 +93,7 @@ public enum LineItemColumn
                     return lineItem.getDiscount();
                 }
 
-                public long getLong(LineItem lineItem)
+                public long getIdentifier(LineItem lineItem)
                 {
                     return lineItem.getDiscountPercent();
                 }
@@ -100,7 +106,7 @@ public enum LineItemColumn
                     return lineItem.getTax();
                 }
 
-                public long getLong(LineItem lineItem)
+                public long getIdentifier(LineItem lineItem)
                 {
                     return lineItem.getTaxPercent();
                 }
@@ -221,7 +227,13 @@ public enum LineItemColumn
     }
 
     @Override
-    public long getLong(LineItem lineItem)
+    public long getIdentifier(LineItem lineItem)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getInteger(LineItem lineItem)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/io/airlift/tpch/NationColumn.java
+++ b/src/main/java/io/airlift/tpch/NationColumn.java
@@ -13,16 +13,16 @@
  */
 package io.airlift.tpch;
 
-import static io.airlift.tpch.TpchColumnType.BIGINT;
+import static io.airlift.tpch.TpchColumnType.IDENTIFIER;
 import static io.airlift.tpch.TpchColumnType.VARCHAR;
 
 public enum NationColumn
         implements TpchColumn<Nation>
 {
     @SuppressWarnings("SpellCheckingInspection")
-    NATION_KEY("nationkey", BIGINT)
+    NATION_KEY("nationkey", IDENTIFIER)
             {
-                public long getLong(Nation nation)
+                public long getIdentifier(Nation nation)
                 {
                     return nation.getNationKey();
                 }
@@ -37,9 +37,9 @@ public enum NationColumn
             },
 
     @SuppressWarnings("SpellCheckingInspection")
-    REGION_KEY("regionkey", BIGINT)
+    REGION_KEY("regionkey", IDENTIFIER)
             {
-                public long getLong(Nation nation)
+                public long getIdentifier(Nation nation)
                 {
                     return nation.getRegionKey();
                 }
@@ -81,7 +81,13 @@ public enum NationColumn
     }
 
     @Override
-    public long getLong(Nation nation)
+    public long getIdentifier(Nation nation)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getInteger(Nation nation)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/io/airlift/tpch/Order.java
+++ b/src/main/java/io/airlift/tpch/Order.java
@@ -29,7 +29,7 @@ public class Order
     private final int orderDate;
     private final String orderPriority;
     private final String clerk;
-    private final long shipPriority;
+    private final int shipPriority;
     private final String comment;
 
     public Order(long rowNumber,
@@ -40,7 +40,7 @@ public class Order
             int orderDate,
             String orderPriority,
             String clerk,
-            long shipPriority,
+            int shipPriority,
             String comment)
     {
         this.rowNumber = rowNumber;
@@ -101,7 +101,7 @@ public class Order
         return clerk;
     }
 
-    public long getShipPriority()
+    public int getShipPriority()
     {
         return shipPriority;
     }

--- a/src/main/java/io/airlift/tpch/OrderColumn.java
+++ b/src/main/java/io/airlift/tpch/OrderColumn.java
@@ -14,27 +14,28 @@
 package io.airlift.tpch;
 
 import static io.airlift.tpch.GenerateUtils.formatDate;
-import static io.airlift.tpch.TpchColumnType.BIGINT;
+import static io.airlift.tpch.TpchColumnType.IDENTIFIER;
 import static io.airlift.tpch.TpchColumnType.DATE;
 import static io.airlift.tpch.TpchColumnType.DOUBLE;
+import static io.airlift.tpch.TpchColumnType.INTEGER;
 import static io.airlift.tpch.TpchColumnType.VARCHAR;
 
 public enum OrderColumn
         implements TpchColumn<Order>
 {
     @SuppressWarnings("SpellCheckingInspection")
-    ORDER_KEY("orderkey", BIGINT)
+    ORDER_KEY("orderkey", IDENTIFIER)
             {
-                public long getLong(Order order)
+                public long getIdentifier(Order order)
                 {
                     return order.getOrderKey();
                 }
             },
 
     @SuppressWarnings("SpellCheckingInspection")
-    CUSTOMER_KEY("custkey", BIGINT)
+    CUSTOMER_KEY("custkey", IDENTIFIER)
             {
-                public long getLong(Order order)
+                public long getIdentifier(Order order)
                 {
                     return order.getCustomerKey();
                 }
@@ -57,7 +58,7 @@ public enum OrderColumn
                     return order.getTotalPrice();
                 }
 
-                public long getLong(Order order)
+                public long getIdentifier(Order order)
                 {
                     return order.getTotalPriceInCents();
                 }
@@ -96,9 +97,9 @@ public enum OrderColumn
             },
 
     @SuppressWarnings("SpellCheckingInspection")
-    SHIP_PRIORITY("shippriority", BIGINT)
+    SHIP_PRIORITY("shippriority", INTEGER)
             {
-                public long getLong(Order order)
+                public int getInteger(Order order)
                 {
                     return order.getShipPriority();
                 }
@@ -140,7 +141,13 @@ public enum OrderColumn
     }
 
     @Override
-    public long getLong(Order order)
+    public long getIdentifier(Order order)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getInteger(Order order)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/io/airlift/tpch/Part.java
+++ b/src/main/java/io/airlift/tpch/Part.java
@@ -26,7 +26,7 @@ public class Part
     private final String manufacturer;
     private final String brand;
     private final String type;
-    private final long size;
+    private final int size;
     private final String container;
     private final long retailPrice;
     private final String comment;
@@ -37,7 +37,7 @@ public class Part
             String manufacturer,
             String brand,
             String type,
-            long size,
+            int size,
             String container,
             long retailPrice,
             String comment)
@@ -85,7 +85,7 @@ public class Part
         return type;
     }
 
-    public long getSize()
+    public int getSize()
     {
         return size;
     }

--- a/src/main/java/io/airlift/tpch/PartColumn.java
+++ b/src/main/java/io/airlift/tpch/PartColumn.java
@@ -13,17 +13,18 @@
  */
 package io.airlift.tpch;
 
-import static io.airlift.tpch.TpchColumnType.BIGINT;
+import static io.airlift.tpch.TpchColumnType.IDENTIFIER;
 import static io.airlift.tpch.TpchColumnType.DOUBLE;
+import static io.airlift.tpch.TpchColumnType.INTEGER;
 import static io.airlift.tpch.TpchColumnType.VARCHAR;
 
 public enum PartColumn
         implements TpchColumn<Part>
 {
     @SuppressWarnings("SpellCheckingInspection")
-    PART_KEY("partkey", BIGINT)
+    PART_KEY("partkey", IDENTIFIER)
             {
-                public long getLong(Part part)
+                public long getIdentifier(Part part)
                 {
                     return part.getPartKey();
                 }
@@ -61,9 +62,9 @@ public enum PartColumn
                 }
             },
 
-    SIZE("size", BIGINT)
+    SIZE("size", INTEGER)
             {
-                public long getLong(Part part)
+                public int getInteger(Part part)
                 {
                     return part.getSize();
                 }
@@ -85,7 +86,7 @@ public enum PartColumn
                     return part.getRetailPrice();
                 }
 
-                public long getLong(Part part)
+                public long getIdentifier(Part part)
                 {
                     return part.getRetailPriceInCents();
                 }
@@ -127,7 +128,13 @@ public enum PartColumn
     }
 
     @Override
-    public long getLong(Part part)
+    public long getIdentifier(Part part)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getInteger(Part part)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/io/airlift/tpch/PartSupplier.java
+++ b/src/main/java/io/airlift/tpch/PartSupplier.java
@@ -23,11 +23,11 @@ public class PartSupplier
     private final long rowNumber;
     private final long partKey;
     private final long supplierKey;
-    private final long availableQuantity;
+    private final int availableQuantity;
     private final long supplyCost;
     private final String comment;
 
-    public PartSupplier(long rowNumber, long partKey, long supplierKey, long availableQuantity, long supplyCost, String comment)
+    public PartSupplier(long rowNumber, long partKey, long supplierKey, int availableQuantity, long supplyCost, String comment)
     {
         this.rowNumber = rowNumber;
         this.partKey = partKey;
@@ -53,7 +53,7 @@ public class PartSupplier
         return supplierKey;
     }
 
-    public long getAvailableQuantity()
+    public int getAvailableQuantity()
     {
         return availableQuantity;
     }

--- a/src/main/java/io/airlift/tpch/PartSupplierColumn.java
+++ b/src/main/java/io/airlift/tpch/PartSupplierColumn.java
@@ -13,35 +13,36 @@
  */
 package io.airlift.tpch;
 
-import static io.airlift.tpch.TpchColumnType.BIGINT;
+import static io.airlift.tpch.TpchColumnType.IDENTIFIER;
 import static io.airlift.tpch.TpchColumnType.DOUBLE;
+import static io.airlift.tpch.TpchColumnType.INTEGER;
 import static io.airlift.tpch.TpchColumnType.VARCHAR;
 
 public enum PartSupplierColumn
         implements TpchColumn<PartSupplier>
 {
     @SuppressWarnings("SpellCheckingInspection")
-    PART_KEY("partkey", BIGINT)
+    PART_KEY("partkey", IDENTIFIER)
             {
-                public long getLong(PartSupplier partSupplier)
+                public long getIdentifier(PartSupplier partSupplier)
                 {
                     return partSupplier.getPartKey();
                 }
             },
 
     @SuppressWarnings("SpellCheckingInspection")
-    SUPPLIER_KEY("suppkey", BIGINT)
+    SUPPLIER_KEY("suppkey", IDENTIFIER)
             {
-                public long getLong(PartSupplier partSupplier)
+                public long getIdentifier(PartSupplier partSupplier)
                 {
                     return partSupplier.getSupplierKey();
                 }
             },
 
     @SuppressWarnings("SpellCheckingInspection")
-    AVAILABLE_QUANTITY("availqty", BIGINT)
+    AVAILABLE_QUANTITY("availqty", INTEGER)
             {
-                public long getLong(PartSupplier partSupplier)
+                public int getInteger(PartSupplier partSupplier)
                 {
                     return partSupplier.getAvailableQuantity();
                 }
@@ -55,7 +56,7 @@ public enum PartSupplierColumn
                     return partSupplier.getSupplyCost();
                 }
 
-                public long getLong(PartSupplier partSupplier)
+                public long getIdentifier(PartSupplier partSupplier)
                 {
                     return partSupplier.getSupplyCostInCents();
                 }
@@ -98,7 +99,13 @@ public enum PartSupplierColumn
     }
 
     @Override
-    public long getLong(PartSupplier partSupplier)
+    public long getIdentifier(PartSupplier partSupplier)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getInteger(PartSupplier partSupplier)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/io/airlift/tpch/RegionColumn.java
+++ b/src/main/java/io/airlift/tpch/RegionColumn.java
@@ -13,16 +13,16 @@
  */
 package io.airlift.tpch;
 
-import static io.airlift.tpch.TpchColumnType.BIGINT;
+import static io.airlift.tpch.TpchColumnType.IDENTIFIER;
 import static io.airlift.tpch.TpchColumnType.VARCHAR;
 
 public enum RegionColumn
         implements TpchColumn<Region>
 {
     @SuppressWarnings("SpellCheckingInspection")
-    REGION_KEY("regionkey", BIGINT)
+    REGION_KEY("regionkey", IDENTIFIER)
             {
-                public long getLong(Region region)
+                public long getIdentifier(Region region)
                 {
                     return region.getRegionKey();
                 }
@@ -72,7 +72,13 @@ public enum RegionColumn
     }
 
     @Override
-    public long getLong(Region region)
+    public long getIdentifier(Region region)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getInteger(Region region)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/io/airlift/tpch/SupplierColumn.java
+++ b/src/main/java/io/airlift/tpch/SupplierColumn.java
@@ -13,7 +13,7 @@
  */
 package io.airlift.tpch;
 
-import static io.airlift.tpch.TpchColumnType.BIGINT;
+import static io.airlift.tpch.TpchColumnType.IDENTIFIER;
 import static io.airlift.tpch.TpchColumnType.DOUBLE;
 import static io.airlift.tpch.TpchColumnType.VARCHAR;
 
@@ -21,9 +21,9 @@ public enum SupplierColumn
         implements TpchColumn<Supplier>
 {
     @SuppressWarnings("SpellCheckingInspection")
-    SUPPLIER_KEY("suppkey", BIGINT)
+    SUPPLIER_KEY("suppkey", IDENTIFIER)
             {
-                public long getLong(Supplier supplier)
+                public long getIdentifier(Supplier supplier)
                 {
                     return supplier.getSupplierKey();
                 }
@@ -46,9 +46,9 @@ public enum SupplierColumn
             },
 
     @SuppressWarnings("SpellCheckingInspection")
-    NATION_KEY("nationkey", BIGINT)
+    NATION_KEY("nationkey", IDENTIFIER)
             {
-                public long getLong(Supplier supplier)
+                public long getIdentifier(Supplier supplier)
                 {
                     return supplier.getNationKey();
                 }
@@ -70,7 +70,7 @@ public enum SupplierColumn
                     return supplier.getAccountBalance();
                 }
 
-                public long getLong(Supplier supplier)
+                public long getIdentifier(Supplier supplier)
                 {
                     return supplier.getAccountBalanceInCents();
                 }
@@ -112,7 +112,13 @@ public enum SupplierColumn
     }
 
     @Override
-    public long getLong(Supplier supplier)
+    public long getIdentifier(Supplier supplier)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getInteger(Supplier supplier)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/io/airlift/tpch/TpchColumn.java
+++ b/src/main/java/io/airlift/tpch/TpchColumn.java
@@ -21,7 +21,9 @@ public interface TpchColumn<E extends TpchEntity>
 
     double getDouble(E entity);
 
-    long getLong(E entity);
+    long getIdentifier(E entity);
+
+    int getInteger(E entity);
 
     String getString(E entity);
 

--- a/src/main/java/io/airlift/tpch/TpchColumnType.java
+++ b/src/main/java/io/airlift/tpch/TpchColumnType.java
@@ -15,5 +15,5 @@ package io.airlift.tpch;
 
 public enum TpchColumnType
 {
-    BIGINT, DATE, DOUBLE, VARCHAR
+    INTEGER, IDENTIFIER, DATE, DOUBLE, VARCHAR
 }


### PR DESCRIPTION
Introduce IDENTIFIER type, and change non-identifier columns to
generate INTEGERs. This more accurately reflects the TPC-H 2.17.1
specification (section 1.3.1).