### PR TITLE
Revert quantity to generate whole number

### DIFF
--- a/src/main/java/io/airlift/tpch/LineItem.java
+++ b/src/main/java/io/airlift/tpch/LineItem.java
@@ -102,12 +102,7 @@ public class LineItem
         return lineNumber;
     }
 
-    public double getQuantity()
-    {
-        return quantity / 100.0;
-    }
-
-    public long getQuantityInCents()
+    public long getQuantity()
     {
         return quantity;
     }

--- a/src/main/java/io/airlift/tpch/LineItemColumn.java
+++ b/src/main/java/io/airlift/tpch/LineItemColumn.java
@@ -68,7 +68,7 @@ public enum LineItemColumn
 
                 public long getIdentifier(LineItem lineItem)
                 {
-                    return lineItem.getQuantityInCents();
+                    return lineItem.getQuantity() * 100;
                 }
             },
 


### PR DESCRIPTION
The previous commit changed the quantity to return DOUBLE instead of
IDENTIFIER. Although these are the correct types, we still want
quantity to be a whole number (even if the type is DOUBLE).